### PR TITLE
Add PHPUnit coverage for force_selection helpers (PR B of #6)

### DIFF
--- a/tests/phpunit/test-enforce-single-term.php
+++ b/tests/phpunit/test-enforce-single-term.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Coverage for of_cme_enforce_single_term().
+ *
+ * Each test corresponds to a regression class identified in the PR #5 review:
+ * sentinel filtering, type coercion of slug strings, force_selection
+ * substitution, and multi-term coercion.
+ */
+
+class Test_Enforce_Single_Term extends WP_UnitTestCase {
+
+	const TAX        = 'cme_test_enforce';
+	const OPTION_KEY = 'category-metabox-enhanced_cme_test_enforce';
+
+	public function set_up() {
+		parent::set_up();
+		register_taxonomy( self::TAX, 'post', array( 'hierarchical' => true ) );
+		update_option( self::OPTION_KEY, array(
+			'type'            => 'radio',
+			'force_selection' => 1,
+		) );
+	}
+
+	public function tear_down() {
+		delete_option( self::OPTION_KEY );
+		delete_option( 'default_' . self::TAX );
+		delete_option( 'default_term_' . self::TAX );
+		unregister_taxonomy( self::TAX );
+		parent::tear_down();
+	}
+
+	/**
+	 * Helper: create a term in the test taxonomy and pin it as the
+	 * legacy default so force_selection resolves deterministically.
+	 */
+	private function pin_default_term() {
+		$term_id = self::factory()->term->create(
+			array(
+				'taxonomy' => self::TAX,
+				'name'     => 'Pinned',
+				'slug'     => 'pinned',
+			)
+		);
+		update_option( 'default_' . self::TAX, $term_id );
+		return $term_id;
+	}
+
+	public function test_non_array_input_passes_through() {
+		$this->assertSame( 'foo', of_cme_enforce_single_term( 'foo', 0, self::TAX ) );
+		$this->assertSame( 42, of_cme_enforce_single_term( 42, 0, self::TAX ) );
+		$this->assertNull( of_cme_enforce_single_term( null, 0, self::TAX ) );
+	}
+
+	public function test_non_hierarchical_taxonomy_passes_through() {
+		// post_tag is non-hierarchical and ships with WordPress, so we can
+		// assert the early return without registering anything custom.
+		$input = array( 10, 20, 30 );
+		$this->assertSame( $input, of_cme_enforce_single_term( $input, 0, 'post_tag' ) );
+	}
+
+	public function test_checkbox_type_passes_through() {
+		update_option( self::OPTION_KEY, array( 'type' => 'checkbox' ) );
+
+		$input = array( 10, 20, 30 );
+		$this->assertSame( $input, of_cme_enforce_single_term( $input, 0, self::TAX ) );
+	}
+
+	public function test_single_valid_id_passes_through() {
+		$this->assertSame( array( 42 ), of_cme_enforce_single_term( array( 42 ), 0, self::TAX ) );
+	}
+
+	public function test_multiple_ids_coerced_to_last() {
+		$this->assertSame( array( 30 ), of_cme_enforce_single_term( array( 10, 20, 30 ), 0, self::TAX ) );
+	}
+
+	public function test_zero_int_filtered_triggers_force_selection() {
+		$default = $this->pin_default_term();
+
+		$this->assertSame( array( $default ), of_cme_enforce_single_term( array( 0 ), 0, self::TAX ) );
+	}
+
+	public function test_zero_string_filtered_triggers_force_selection() {
+		$default = $this->pin_default_term();
+
+		$this->assertSame( array( $default ), of_cme_enforce_single_term( array( '0' ), 0, self::TAX ) );
+	}
+
+	public function test_slug_string_preserved() {
+		// Regression for the `(int) 'slug' === 0` bug: pre_set_object_terms
+		// fires before WP resolves slugs to IDs, so a slug like 'my-category'
+		// must survive the sentinel filter.
+		$this->assertSame(
+			array( 'my-category' ),
+			of_cme_enforce_single_term( array( 'my-category' ), 0, self::TAX )
+		);
+	}
+
+	public function test_mixed_id_and_zero_filters_zero() {
+		// [5, 0] should drop the sentinel and pass the surviving single ID
+		// through without triggering substitution.
+		$this->assertSame( array( 5 ), of_cme_enforce_single_term( array( 5, 0 ), 0, self::TAX ) );
+	}
+
+	public function test_empty_with_force_selection_substitutes_default() {
+		$default = $this->pin_default_term();
+
+		$this->assertSame( array( $default ), of_cme_enforce_single_term( array(), 0, self::TAX ) );
+	}
+
+	public function test_empty_without_force_selection_passes_through() {
+		update_option( self::OPTION_KEY, array(
+			'type'            => 'radio',
+			'force_selection' => 0,
+		) );
+
+		$this->assertSame( array(), of_cme_enforce_single_term( array(), 0, self::TAX ) );
+	}
+}

--- a/tests/phpunit/test-resolve-default-term.php
+++ b/tests/phpunit/test-resolve-default-term.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Coverage for of_cme_resolve_default_term().
+ *
+ * Verifies the four-step resolution chain:
+ *   1. default_<tax>      (legacy option)
+ *   2. default_term_<tax> (modern option, WP 5.5+)
+ *   3. WP_Taxonomy::default_term (register_taxonomy default_term arg)
+ *   4. first term by name asc
+ * plus the of_cme_force_selection_default_term filter override.
+ */
+
+class Test_Resolve_Default_Term extends WP_UnitTestCase {
+
+	const TAX = 'cme_test_resolve';
+
+	/**
+	 * Slug of any extra taxonomy a single test registered. Tracked so
+	 * tear_down can clean up even when an assertion fails before the
+	 * test reaches its own teardown.
+	 *
+	 * @var string
+	 */
+	private $extra_tax = '';
+
+	public function set_up() {
+		parent::set_up();
+		register_taxonomy( self::TAX, 'post', array( 'hierarchical' => true ) );
+	}
+
+	public function tear_down() {
+		delete_option( 'default_' . self::TAX );
+		delete_option( 'default_term_' . self::TAX );
+		unregister_taxonomy( self::TAX );
+		if ( '' !== $this->extra_tax ) {
+			delete_option( 'default_' . $this->extra_tax );
+			delete_option( 'default_term_' . $this->extra_tax );
+			unregister_taxonomy( $this->extra_tax );
+			$this->extra_tax = '';
+		}
+		remove_all_filters( 'of_cme_force_selection_default_term' );
+		parent::tear_down();
+	}
+
+	private function create_term( $name, $slug = '' ) {
+		return self::factory()->term->create(
+			array(
+				'taxonomy' => self::TAX,
+				'name'     => $name,
+				'slug'     => $slug ? $slug : sanitize_title( $name ),
+			)
+		);
+	}
+
+	public function test_legacy_option_resolves_term() {
+		$term_id = $this->create_term( 'Legacy' );
+		update_option( 'default_' . self::TAX, $term_id );
+
+		$this->assertSame( $term_id, of_cme_resolve_default_term( self::TAX ) );
+	}
+
+	public function test_modern_option_resolves_term() {
+		$term_id = $this->create_term( 'Modern' );
+		update_option( 'default_term_' . self::TAX, $term_id );
+
+		$this->assertSame( $term_id, of_cme_resolve_default_term( self::TAX ) );
+	}
+
+	public function test_legacy_wins_when_both_set() {
+		$legacy = $this->create_term( 'Legacy' );
+		$modern = $this->create_term( 'Modern' );
+		update_option( 'default_' . self::TAX, $legacy );
+		update_option( 'default_term_' . self::TAX, $modern );
+
+		$this->assertSame( $legacy, of_cme_resolve_default_term( self::TAX ) );
+	}
+
+	public function test_falls_through_when_option_term_deleted() {
+		// Stale option references a term that no longer exists; resolver
+		// must skip it and fall through to the next path. With no default_term
+		// registered, the alphabetic fallback kicks in — 'Aaa' wins over 'Zzz'.
+		$ghost     = $this->create_term( 'Ghost' );
+		$surviving = $this->create_term( 'Aaa' );
+		$this->create_term( 'Zzz' );
+		update_option( 'default_' . self::TAX, $ghost );
+		wp_delete_term( $ghost, self::TAX );
+
+		$this->assertSame( $surviving, of_cme_resolve_default_term( self::TAX ) );
+	}
+
+	public function test_register_taxonomy_default_term_with_slug() {
+		// Exercise the third resolution step: WP_Taxonomy::default_term arg
+		// resolved via get_term_by('slug', ...). register_taxonomy with the
+		// default_term arg auto-creates the term *and* the modern option, so
+		// we drop the option to isolate the slug-lookup branch. tear_down
+		// owns the unregister so a failing assertion can't leak this
+		// taxonomy into the rest of the suite.
+		$this->extra_tax = 'cme_test_with_default';
+		register_taxonomy( $this->extra_tax, 'post', array(
+			'hierarchical' => true,
+			'default_term' => array(
+				'name' => 'Default Test',
+				'slug' => 'default-test',
+			),
+		) );
+		delete_option( 'default_term_' . $this->extra_tax );
+
+		$term = get_term_by( 'slug', 'default-test', $this->extra_tax );
+		$this->assertInstanceOf( 'WP_Term', $term );
+		$this->assertSame( (int) $term->term_id, of_cme_resolve_default_term( $this->extra_tax ) );
+	}
+
+	public function test_falls_through_to_first_by_name() {
+		$first = $this->create_term( 'Alpha' );
+		$this->create_term( 'Beta' );
+
+		$this->assertSame( $first, of_cme_resolve_default_term( self::TAX ) );
+	}
+
+	public function test_returns_zero_when_taxonomy_has_no_terms() {
+		$this->assertSame( 0, of_cme_resolve_default_term( self::TAX ) );
+	}
+
+	public function test_filter_overrides_resolution() {
+		$natural  = $this->create_term( 'Natural' );
+		$override = $this->create_term( 'Override' );
+
+		add_filter(
+			'of_cme_force_selection_default_term',
+			static function ( $default, $taxonomy ) use ( $override ) {
+				return $override;
+			},
+			10,
+			2
+		);
+
+		$this->assertSame( $override, of_cme_resolve_default_term( self::TAX ) );
+		$this->assertNotSame( $natural, of_cme_resolve_default_term( self::TAX ) );
+	}
+}


### PR DESCRIPTION
## Summary

PR B of #6. Locks down every regression class identified in the PR #5 review by exercising `of_cme_enforce_single_term` and `of_cme_resolve_default_term` across their full branch surface.

### `tests/phpunit/test-enforce-single-term.php` (11 tests)

- Non-array, non-hierarchical taxonomy, and `checkbox` type all pass through (early returns).
- Single valid ID and **slug string** inputs survive the sentinel filter — the slug case is the regression for the `(int) 'my-category' === 0` bug, since `pre_set_object_terms` fires before WP resolves slugs to IDs.
- Multi-ID arrays coerce to `[end()]`.
- `[0]`, `['0']`, and `[5, 0]` are filtered correctly; the all-zero cases trigger `force_selection` substitution.
- Empty input substitutes when `force_selection` is on, passes through when off.

### `tests/phpunit/test-resolve-default-term.php` (8 tests)

- Legacy `default_<tax>` option, modern `default_term_<tax>` option (WP 5.5+), and the legacy-wins precedence when both are set.
- A deleted term referenced by the option falls through to the next path (`term_exists` guard).
- `register_taxonomy` `default_term` arg resolves via `get_term_by('slug', ...)`.
- Alphabetic first-by-name fallback fires when nothing else is configured.
- Taxonomy with zero terms returns `0`.
- `of_cme_force_selection_default_term` filter overrides everything.

## Notes on test design

- Each suite registers a custom hierarchical taxonomy in `set_up()` (e.g. `cme_test_enforce`, `cme_test_resolve`) to avoid coupling to the shared `category` state.
- The `default_term`-arg test pins the registered slug on the test instance so `tear_down` can unregister it even if an assertion fails before the test reaches its own teardown — protects the rest of the suite from leaked `$wp_taxonomies` entries.
- Tests use direct function calls rather than going through `pre_set_object_terms` to keep them fast and unit-focused; end-to-end REST/Block-Editor coverage is PR C's territory.

## Test plan

- [x] Local: `composer test` → 22 tests, 29 assertions, ~250ms (well under the <5s acceptance criterion)
- [x] Each file passes in isolation via `--filter`: 11/11 enforce, 8/8 resolve, 3/3 smoke
- [ ] CI: PHPUnit job goes green
- [ ] CI: Build freshness job goes green

Refs #6 (do not auto-close — PR C still pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/1fixdotio/categories-metabox-enhanced/pull/8" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
