### PR TITLE
Fix dead pre_set_object_terms hook (0.9.0 regression)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Donate link: http://1fix.io/
 Tags: category, metabox, taxonomy
 Requires at least: 5.5
 Tested up to: 6.7
-Stable tag: 0.9.0
+Stable tag: 0.9.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -41,13 +41,16 @@ The substituted default term resolves in this order: the `default_<taxonomy>` op
 
 == Changelog ==
 
+= 0.9.1 =
+* Fix server-side single-term enforcement, which was registered against `pre_set_object_terms` — a hook that does not exist in WordPress core — and never executed in 0.9.0. The handler now hooks `set_object_terms` and re-issues `wp_set_object_terms` with a corrected list when the single-term contract is violated, so REST and programmatic callers are now actually enforced. The classic-editor metabox path was unaffected; it relies on UI-level enforcement.
+
 = 0.9.0 =
-* Add a "Force selection" per-taxonomy setting (defaults on) replacing the previously hardcoded classic-editor behavior. When on, the Block Editor sidebar suppresses "— Select —" once a term is chosen, and the server-side `pre_set_object_terms` filter substitutes a default term for empty submissions on radio/select taxonomies — closing the bypass that REST and programmatic callers had on the single-term invariant.
+* Add a "Force selection" per-taxonomy setting (defaults on) replacing the previously hardcoded classic-editor behavior. When on, the Block Editor sidebar suppresses "— Select —" once a term is chosen, and the server-side handler substitutes a default term for empty submissions on radio/select taxonomies — closing the bypass that REST and programmatic callers had on the single-term invariant. (The 0.9.0 release wired this handler against the wrong hook name; see 0.9.1.)
 * The substituted term resolves in this order: `default_<taxonomy>` option → `default_term` registered with the taxonomy (WP 5.5+) → first term by name asc. Filterable via `of_cme_force_selection_default_term`. Mirrors the classic library's `process_default()` pattern.
 
 = 0.8.0 =
 * Replace the legacy Block Editor integration with a native sidebar panel built on `@wordpress/components` (`TreeSelect` / radio tree) and `PluginDocumentSettingPanel`.
-* Add server-side single-term enforcement on `pre_set_object_terms` so REST and programmatic saves can't bypass the radio/select invariant.
+* Add server-side single-term enforcement so REST and programmatic saves can't bypass the radio/select invariant. (Released against the wrong hook name; superseded by 0.9.1.)
 * The classic-editor metabox path is unchanged; it now skips post types that use the Block Editor to avoid duplicate UI.
 
 = 0.7.1 =

--- a/categories-metabox-enhanced.php
+++ b/categories-metabox-enhanced.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Categories Metabox Enhanced
  * Plugin URI:        https://1fix.io/category-metabox-enhanced/
  * Description:       Replace the checkboxes with radio buttons or a select drop-down in the built-in Categories metabox and the Block Editor sidebar panel.
- * Version:           0.9.0
+ * Version:           0.9.1
  * Requires at least: 5.5
  * Author:            1Fix.io
  * Author URI:        https://1fix.io/

--- a/includes/class-category-metabox-enhanced.php
+++ b/includes/class-category-metabox-enhanced.php
@@ -69,7 +69,7 @@ class Category_Metabox_Enhanced {
 	public function __construct() {
 
 		$this->plugin_name = 'category-metabox-enhanced';
-		$this->version     = '0.9.0';
+		$this->version     = '0.9.1';
 
 		$this->load_dependencies();
 		$this->set_locale();

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -66,65 +66,95 @@ function of_cme_is_single_term_type( $type ) {
 }
 
 /**
- * Enforce the single-term invariant for taxonomies configured as radio/select.
+ * Enforce the single-term invariant after WordPress commits term assignments.
  *
- * Two cases:
- *   - >1 terms: coerce to the last one (UI sends one, but REST/programmatic
- *     callers can still submit multiple).
- *   - 0 terms with force_selection on: substitute the first available term.
- *     This is the only place a UI-bypassing caller (REST, wp-cli) can be
- *     stopped from creating an empty assignment for a taxonomy that's
- *     configured to require one.
+ * WordPress core does not expose a pre-write filter on object terms —
+ * `wp_set_object_terms` only fires the `set_object_terms` action after the
+ * relationships are written. We hook that action, inspect the committed
+ * state, and re-issue `wp_set_object_terms` with corrected IDs when the
+ * single-term contract is violated. A static recursion guard ensures the
+ * re-issue does not trigger a second pass.
  *
- * @since 0.8.0
+ * Two cases trigger correction:
+ *   - >1 terms committed: coerce to the last (matches Taxonomy_Single_Term
+ *     classic-editor semantics).
+ *   - 0 terms committed AND force_selection on: substitute the resolved
+ *     default term, closing the bypass that REST and programmatic callers
+ *     would otherwise have on the single-term invariant.
  *
- * @param array<int|string>|string $terms     Terms being assigned.
- * @param int                      $object_id Unused.
- * @param string                   $taxonomy  Taxonomy slug.
- * @return array<int|string>|string
+ * Append-mode calls are skipped: a caller that explicitly appends should
+ * not have prior terms removed by us.
+ *
+ * Note: other listeners on `set_object_terms` see the uncorrected state
+ * briefly, then a second action fires with the correction. Anything that
+ * caches "current terms" in this action will cache wrong then re-cache.
+ * This is the trade-off for not having a pre-write hook.
+ *
+ * @since 0.9.1
+ *
+ * @param int           $object_id  Object ID receiving the terms.
+ * @param array         $terms      Terms originally passed to wp_set_object_terms.
+ * @param array         $tt_ids     Term taxonomy IDs that were set.
+ * @param string        $taxonomy   Taxonomy slug.
+ * @param bool          $append     Whether the call appended rather than replaced.
+ * @param array         $old_tt_ids Old term taxonomy IDs before the write.
  */
-function of_cme_enforce_single_term( $terms, $object_id, $taxonomy ) {
+function of_cme_enforce_single_term( $object_id, $terms, $tt_ids, $taxonomy, $append, $old_tt_ids ) {
 
-	if ( ! is_array( $terms ) ) {
-		return $terms;
+	static $reentering = false;
+	if ( $reentering ) {
+		return;
+	}
+
+	if ( $append ) {
+		return;
 	}
 
 	if ( ! is_taxonomy_hierarchical( $taxonomy ) ) {
-		return $terms;
+		return;
 	}
 
 	$options = of_cme_get_taxonomy_options( $taxonomy );
 	if ( ! of_cme_is_single_term_type( $options['type'] ) ) {
-		return $terms;
+		return;
 	}
 
-	// Drop the "no selection" sentinel ([0]/['0']) so it doesn't bypass the
-	// force_selection branch as a count-of-one. is_numeric gates the int
-	// cast because (int) 'my-category' is 0 in PHP, and pre_set_object_terms
-	// fires before WP resolves slugs/names to IDs.
-	$filtered = array_values(
-		array_filter(
-			$terms,
-			static function ( $term ) {
-				return ! is_numeric( $term ) || 0 !== (int) $term;
-			}
+	$current_ids = wp_get_object_terms(
+		$object_id,
+		$taxonomy,
+		array(
+			'fields'                 => 'ids',
+			'orderby'                => 'none',
+			'hide_empty'             => false,
+			'update_term_meta_cache' => false,
 		)
 	);
-
-	if ( count( $filtered ) > 1 ) {
-		return array( end( $filtered ) );
+	if ( is_wp_error( $current_ids ) ) {
+		return;
 	}
 
-	if ( count( $filtered ) === 0 && ! empty( $options['force_selection'] ) ) {
+	$count        = count( $current_ids );
+	$new_ids      = $current_ids;
+	$needs_change = false;
+
+	if ( $count > 1 ) {
+		$new_ids      = array( (int) end( $current_ids ) );
+		$needs_change = true;
+	} elseif ( 0 === $count && ! empty( $options['force_selection'] ) ) {
 		$default = of_cme_resolve_default_term( $taxonomy );
 		if ( $default ) {
-			return array( $default );
+			$new_ids      = array( $default );
+			$needs_change = true;
 		}
 	}
 
-	return $filtered;
+	if ( $needs_change ) {
+		$reentering = true;
+		wp_set_object_terms( $object_id, $new_ids, $taxonomy, false );
+		$reentering = false;
+	}
 }
-add_filter( 'pre_set_object_terms', 'of_cme_enforce_single_term', 10, 3 );
+add_action( 'set_object_terms', 'of_cme_enforce_single_term', 10, 6 );
 
 /**
  * Resolve the term to substitute for an empty force_selection submission.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "categories-metabox-enhanced",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Replace the checkboxes with radio buttons or a select drop-down in the built-in Categories metabox and Block Editor sidebar.",
   "private": true,
   "license": "GPL-2.0+",

--- a/tests/phpunit/test-enforce-single-term.php
+++ b/tests/phpunit/test-enforce-single-term.php
@@ -1,16 +1,20 @@
 <?php
 /**
- * Coverage for of_cme_enforce_single_term().
+ * Integration coverage for of_cme_enforce_single_term().
  *
- * Each test corresponds to a regression class identified in the PR #5 review:
- * sentinel filtering, type coercion of slug strings, force_selection
- * substitution, and multi-term coercion.
+ * The function is hooked on `set_object_terms` (post-write action), not
+ * tested in isolation, because the regression in 0.9.0 was a hook-name typo
+ * that function-level tests can't catch. Each test calls wp_set_object_terms
+ * — the integration path real callers take — and asserts the resulting term
+ * assignment.
  */
 
 class Test_Enforce_Single_Term extends WP_UnitTestCase {
 
 	const TAX        = 'cme_test_enforce';
 	const OPTION_KEY = 'category-metabox-enhanced_cme_test_enforce';
+
+	private $term_ids = array();
 
 	public function set_up() {
 		parent::set_up();
@@ -19,6 +23,13 @@ class Test_Enforce_Single_Term extends WP_UnitTestCase {
 			'type'            => 'radio',
 			'force_selection' => 1,
 		) );
+
+		// Predictable term set for substitution + multi-term tests.
+		$this->term_ids = array(
+			'alpha' => self::factory()->term->create( array( 'taxonomy' => self::TAX, 'name' => 'Alpha', 'slug' => 'alpha' ) ),
+			'beta'  => self::factory()->term->create( array( 'taxonomy' => self::TAX, 'name' => 'Beta',  'slug' => 'beta'  ) ),
+			'gamma' => self::factory()->term->create( array( 'taxonomy' => self::TAX, 'name' => 'Gamma', 'slug' => 'gamma' ) ),
+		);
 	}
 
 	public function tear_down() {
@@ -29,82 +40,60 @@ class Test_Enforce_Single_Term extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
+	private function create_post() {
+		return self::factory()->post->create( array( 'post_status' => 'publish' ) );
+	}
+
+	private function get_post_term_ids( $post_id ) {
+		return wp_get_object_terms( $post_id, self::TAX, array( 'fields' => 'ids', 'orderby' => 'term_id' ) );
+	}
+
 	/**
-	 * Helper: create a term in the test taxonomy and pin it as the
-	 * legacy default so force_selection resolves deterministically.
+	 * Meta-test — proves the action is wired to `set_object_terms` so a
+	 * future hook-name typo (the 0.9.0 regression) breaks the suite.
 	 */
-	private function pin_default_term() {
-		$term_id = self::factory()->term->create(
-			array(
-				'taxonomy' => self::TAX,
-				'name'     => 'Pinned',
-				'slug'     => 'pinned',
-			)
-		);
-		update_option( 'default_' . self::TAX, $term_id );
-		return $term_id;
-	}
-
-	public function test_non_array_input_passes_through() {
-		$this->assertSame( 'foo', of_cme_enforce_single_term( 'foo', 0, self::TAX ) );
-		$this->assertSame( 42, of_cme_enforce_single_term( 42, 0, self::TAX ) );
-		$this->assertNull( of_cme_enforce_single_term( null, 0, self::TAX ) );
-	}
-
-	public function test_non_hierarchical_taxonomy_passes_through() {
-		// post_tag is non-hierarchical and ships with WordPress, so we can
-		// assert the early return without registering anything custom.
-		$input = array( 10, 20, 30 );
-		$this->assertSame( $input, of_cme_enforce_single_term( $input, 0, 'post_tag' ) );
-	}
-
-	public function test_checkbox_type_passes_through() {
-		update_option( self::OPTION_KEY, array( 'type' => 'checkbox' ) );
-
-		$input = array( 10, 20, 30 );
-		$this->assertSame( $input, of_cme_enforce_single_term( $input, 0, self::TAX ) );
-	}
-
-	public function test_single_valid_id_passes_through() {
-		$this->assertSame( array( 42 ), of_cme_enforce_single_term( array( 42 ), 0, self::TAX ) );
-	}
-
-	public function test_multiple_ids_coerced_to_last() {
-		$this->assertSame( array( 30 ), of_cme_enforce_single_term( array( 10, 20, 30 ), 0, self::TAX ) );
-	}
-
-	public function test_zero_int_filtered_triggers_force_selection() {
-		$default = $this->pin_default_term();
-
-		$this->assertSame( array( $default ), of_cme_enforce_single_term( array( 0 ), 0, self::TAX ) );
-	}
-
-	public function test_zero_string_filtered_triggers_force_selection() {
-		$default = $this->pin_default_term();
-
-		$this->assertSame( array( $default ), of_cme_enforce_single_term( array( '0' ), 0, self::TAX ) );
-	}
-
-	public function test_slug_string_preserved() {
-		// Regression for the `(int) 'slug' === 0` bug: pre_set_object_terms
-		// fires before WP resolves slugs to IDs, so a slug like 'my-category'
-		// must survive the sentinel filter.
-		$this->assertSame(
-			array( 'my-category' ),
-			of_cme_enforce_single_term( array( 'my-category' ), 0, self::TAX )
+	public function test_action_is_registered_on_set_object_terms() {
+		$this->assertNotFalse(
+			has_action( 'set_object_terms', 'of_cme_enforce_single_term' ),
+			'of_cme_enforce_single_term must be hooked on set_object_terms; that hook is the only post-write integration point WP exposes for term assignments.'
 		);
 	}
 
-	public function test_mixed_id_and_zero_filters_zero() {
-		// [5, 0] should drop the sentinel and pass the surviving single ID
-		// through without triggering substitution.
-		$this->assertSame( array( 5 ), of_cme_enforce_single_term( array( 5, 0 ), 0, self::TAX ) );
+	public function test_single_term_passes_through() {
+		$post_id = $this->create_post();
+		wp_set_object_terms( $post_id, array( $this->term_ids['beta'] ), self::TAX );
+
+		$this->assertSame( array( $this->term_ids['beta'] ), $this->get_post_term_ids( $post_id ) );
+	}
+
+	public function test_multiple_terms_coerced_to_last() {
+		$post_id = $this->create_post();
+		wp_set_object_terms(
+			$post_id,
+			array( $this->term_ids['alpha'], $this->term_ids['beta'], $this->term_ids['gamma'] ),
+			self::TAX
+		);
+
+		$this->assertSame( array( $this->term_ids['gamma'] ), $this->get_post_term_ids( $post_id ) );
 	}
 
 	public function test_empty_with_force_selection_substitutes_default() {
-		$default = $this->pin_default_term();
+		// Alpha is alphabetically first — falls through to the resolver's
+		// first-by-name path when no default option is set.
+		$post_id = $this->create_post();
+		wp_set_object_terms( $post_id, array(), self::TAX );
 
-		$this->assertSame( array( $default ), of_cme_enforce_single_term( array(), 0, self::TAX ) );
+		$this->assertSame( array( $this->term_ids['alpha'] ), $this->get_post_term_ids( $post_id ) );
+	}
+
+	public function test_zero_sentinel_with_force_selection_substitutes_default() {
+		// [0] reaches wp_set_object_terms which drops it during term resolution
+		// (term_exists(0) returns null, is_int(0) skip branch). Net committed
+		// state is empty, so our action substitutes the default.
+		$post_id = $this->create_post();
+		wp_set_object_terms( $post_id, array( 0 ), self::TAX );
+
+		$this->assertSame( array( $this->term_ids['alpha'] ), $this->get_post_term_ids( $post_id ) );
 	}
 
 	public function test_empty_without_force_selection_passes_through() {
@@ -113,6 +102,62 @@ class Test_Enforce_Single_Term extends WP_UnitTestCase {
 			'force_selection' => 0,
 		) );
 
-		$this->assertSame( array(), of_cme_enforce_single_term( array(), 0, self::TAX ) );
+		$post_id = $this->create_post();
+		wp_set_object_terms( $post_id, array(), self::TAX );
+
+		$this->assertSame( array(), $this->get_post_term_ids( $post_id ) );
+	}
+
+	public function test_pinned_default_term_wins_over_first_by_name() {
+		update_option( 'default_' . self::TAX, $this->term_ids['gamma'] );
+
+		$post_id = $this->create_post();
+		wp_set_object_terms( $post_id, array(), self::TAX );
+
+		$this->assertSame( array( $this->term_ids['gamma'] ), $this->get_post_term_ids( $post_id ) );
+	}
+
+	public function test_checkbox_type_is_not_coerced() {
+		update_option( self::OPTION_KEY, array( 'type' => 'checkbox' ) );
+
+		$post_id = $this->create_post();
+		wp_set_object_terms(
+			$post_id,
+			array( $this->term_ids['alpha'], $this->term_ids['beta'] ),
+			self::TAX
+		);
+
+		$this->assertEqualsCanonicalizing(
+			array( $this->term_ids['alpha'], $this->term_ids['beta'] ),
+			$this->get_post_term_ids( $post_id )
+		);
+	}
+
+	public function test_non_hierarchical_taxonomy_is_not_coerced() {
+		// post_tag ships non-hierarchical, so we can verify the early return
+		// without registering yet another taxonomy.
+		$post_id = $this->create_post();
+		$tag1    = self::factory()->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'one' ) );
+		$tag2    = self::factory()->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'two' ) );
+
+		wp_set_object_terms( $post_id, array( $tag1, $tag2 ), 'post_tag' );
+
+		$this->assertEqualsCanonicalizing(
+			array( $tag1, $tag2 ),
+			wp_get_object_terms( $post_id, 'post_tag', array( 'fields' => 'ids' ) )
+		);
+	}
+
+	public function test_append_mode_is_not_coerced() {
+		// Append mode is the one path that intentionally adds to the existing
+		// set; coercing would surprise callers like wp_add_object_terms.
+		$post_id = $this->create_post();
+		wp_set_object_terms( $post_id, array( $this->term_ids['alpha'] ), self::TAX );
+		wp_set_object_terms( $post_id, array( $this->term_ids['beta'] ), self::TAX, true );
+
+		$this->assertEqualsCanonicalizing(
+			array( $this->term_ids['alpha'], $this->term_ids['beta'] ),
+			$this->get_post_term_ids( $post_id )
+		);
 	}
 }


### PR DESCRIPTION
## Summary

- `pre_set_object_terms` is not a WordPress core hook. The server-side enforcement added in 0.9.0 was registered against that name and never executed; REST and programmatic callers continued to bypass the radio/select single-term invariant despite PR #5's commit message claiming the bypass was closed.
- Switches the handler to `set_object_terms` (the only post-write action `wp_set_object_terms` fires) and re-issues the call with a corrected list when the contract is violated. Static recursion guard; append mode skipped.
- Rewrites the enforce-single-term PHPUnit suite as integration tests that drive the real `wp_set_object_terms` path, plus a meta-test asserting the action is hooked on `set_object_terms` so a future hook-name typo breaks the suite.
- Bumps to 0.9.1.

## Discovery

While scaffolding the Playwright e2e suite for #6 (PR C), the very first REST round-trip — `POST /wp/v2/posts` with `cme_e2e_no_default_terms: []` and `force_selection=1` — left the post with no terms instead of substituting the default. Three confirmations before declaring the bug:

1. `grep -rn "pre_set_object_terms" /var/www/html/wp-includes/ /var/www/html/wp-admin/` → zero matches.
2. `wp_set_object_terms` source contains only `do_action('add_term_relationship'/'added_term_relationship'/'set_object_terms')` — no filters in that function.
3. Direct `wp_set_object_terms($id, [], $tax)` in a wp-cli `eval` reproduces the same uncorrected `[]` outcome.

The PHPUnit tests landed in PR #8 passed because they invoked `of_cme_enforce_single_term($terms, 0, $tax)` as a plain function call, bypassing the hook system. They covered the function's internal logic but proved nothing about the integration the docblock claimed.

## Why `set_object_terms` (post-write) and not a pre-write filter

There is no pre-write filter on object terms in WP core. `rest_pre_insert_{post_type}` is REST-only; `wp_insert_post_data` doesn't see term assignments. All three call paths (REST, classic editor, raw `wp_set_object_terms`) converge on `wp_set_object_terms`, and that function exposes only `set_object_terms` after the write. Re-issuing with a recursion guard is the only universal fix.

Trade-off worth flagging: other listeners on `set_object_terms` see the uncorrected state briefly, then a second action fires with the correction. Anything that caches "current terms" on this action will cache wrong then re-cache. Documented inline.

## What changed in the PHPUnit suite

- All enforce-single-term tests now drive `wp_set_object_terms` and read back via `wp_get_object_terms`, exercising the real WP integration path.
- Dropped the slug-preservation test (`['my-category']`). Slugs are resolved to IDs by `wp_set_object_terms` before our action sees them, so the `(int) 'slug' === 0` regression class no longer applies under the new hook.
- Added `test_action_is_registered_on_set_object_terms` as a cheap canary against future hook-name typos.

`test-resolve-default-term.php` is unchanged — `of_cme_resolve_default_term` is unaffected by the hook switch.

## Test plan

- [x] `vendor/bin/phpunit` — 21/21 passing locally
- [x] Manual wp-cli reproduction confirmed the bug exists on `develop` (this branch's parent) and is fixed on this branch
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/1fixdotio/categories-metabox-enhanced/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
