### PR TITLE
Add PHPUnit coverage for settings validate_inputs

### DIFF
--- a/tests/phpunit/test-validate-inputs.php
+++ b/tests/phpunit/test-validate-inputs.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Coverage for Category_Metabox_Enhanced_Settings_Settings::validate_inputs.
+ *
+ * The validator runs as register_setting's `sanitize_callback` on every
+ * settings save. A regression here silently corrupts every saved option
+ * for every taxonomy, so even a few cheap PHPUnit assertions are
+ * disproportionately load-bearing.
+ */
+
+class Test_Validate_Inputs extends WP_UnitTestCase {
+
+	/**
+	 * @var Category_Metabox_Enhanced_Settings_Settings
+	 */
+	private $settings;
+
+	public function set_up() {
+		parent::set_up();
+		$this->settings = new Category_Metabox_Enhanced_Settings_Settings( 'category-metabox-enhanced' );
+	}
+
+	public function tear_down() {
+		remove_all_filters( 'cme_validate_inputs' );
+		parent::tear_down();
+	}
+
+	public function test_full_input_preserves_all_default_keys() {
+		$inputs = array(
+			'type'            => 'radio',
+			'context'         => 'side',
+			'priority'        => 'default',
+			'metabox_title'   => 'My Title',
+			'indented'        => 1,
+			'allow_new_terms' => 1,
+			'force_selection' => 1,
+		);
+
+		$output = $this->settings->validate_inputs( $inputs );
+
+		$this->assertEqualsCanonicalizing( array_keys( of_cme_get_defaults() ), array_keys( $output ) );
+		$this->assertSame( 'radio', $output['type'] );
+		$this->assertSame( 'My Title', $output['metabox_title'] );
+		$this->assertSame( '1', $output['force_selection'] );
+	}
+
+	public function test_missing_checkbox_field_defaults_to_zero() {
+		// Unchecked checkboxes don't appear in $_POST. The validator must
+		// substitute 0 so the saved option doesn't keep the previous value.
+		// This is the regression class that breaks "uncheck Force selection,
+		// save, reload" — i.e. the e2e settings spec, but at the unit layer.
+		$inputs = array(
+			'type'            => 'radio',
+			'context'         => 'side',
+			'priority'        => 'default',
+			'metabox_title'   => '',
+			'indented'        => 1,
+			'allow_new_terms' => 1,
+			// force_selection intentionally omitted.
+		);
+
+		$output = $this->settings->validate_inputs( $inputs );
+
+		$this->assertSame( 0, $output['force_selection'] );
+	}
+
+	public function test_empty_input_zero_fills_every_default_key() {
+		$output = $this->settings->validate_inputs( array() );
+
+		foreach ( array_keys( of_cme_get_defaults() ) as $key ) {
+			$this->assertSame( 0, $output[ $key ], "Key {$key} should default to 0 when absent from input." );
+		}
+	}
+
+	public function test_unknown_keys_are_dropped() {
+		// The validator iterates over of_cme_get_defaults(), so anything not
+		// in that list is silently discarded — important if a malicious or
+		// stale form submission carries extra fields.
+		$inputs = array(
+			'type'        => 'radio',
+			'evil_field'  => 'should_not_persist',
+			'admin_email' => 'attacker@example.com',
+		);
+
+		$output = $this->settings->validate_inputs( $inputs );
+
+		$this->assertArrayNotHasKey( 'evil_field', $output );
+		$this->assertArrayNotHasKey( 'admin_email', $output );
+	}
+
+	public function test_html_and_script_tags_are_stripped() {
+		// validate_inputs runs each value through sanitize_text_field, which
+		// strips tags and normalizes whitespace. Asserts the wiring is in
+		// place; sanitize_text_field's own behavior is WP's responsibility.
+		$inputs = array(
+			'metabox_title' => '<script>alert(1)</script>News',
+		);
+
+		$output = $this->settings->validate_inputs( $inputs );
+
+		$this->assertSame( 'News', $output['metabox_title'] );
+	}
+
+	public function test_cme_validate_inputs_filter_can_override_output() {
+		// Third-party extension point. The filter receives ($outputs, $inputs)
+		// — both useful for consumers that need to react to raw form data
+		// before it lands in the option.
+		add_filter(
+			'cme_validate_inputs',
+			static function ( $outputs, $inputs ) {
+				$outputs['type'] = 'checkbox';
+				return $outputs;
+			},
+			10,
+			2
+		);
+
+		$output = $this->settings->validate_inputs( array( 'type' => 'radio' ) );
+
+		$this->assertSame( 'checkbox', $output['type'] );
+	}
+}


### PR DESCRIPTION
## Summary

Closes the highest-leverage PHPUnit gap left after #6's three-PR plan: `validate_inputs`, the `register_setting` `sanitize_callback` that runs on every settings save. A regression there silently corrupts every saved option for every taxonomy, so even six cheap tests are disproportionately load-bearing.

## What's covered

| Test | What it pins down |
|---|---|
| `test_full_input_preserves_all_default_keys` | Happy path: every default key round-trips |
| `test_missing_checkbox_field_defaults_to_zero` | Unchecked checkboxes fall through to 0 — the unit-layer pin for the Settings page Playwright spec |
| `test_empty_input_zero_fills_every_default_key` | `[]` input → all defaults set to 0, no leftover state |
| `test_unknown_keys_are_dropped` | Validator iterates `of_cme_get_defaults()` keys; extras (stale form fields, attacker-injected fields) are discarded |
| `test_html_and_script_tags_are_stripped` | Wiring of `sanitize_text_field` is asserted (its own behavior is WP core's responsibility) |
| `test_cme_validate_inputs_filter_can_override_output` | Third-party extension point fires with `(outputs, inputs)` |

## Test plan

- [x] `vendor/bin/phpunit --filter Test_Validate_Inputs` — 6/6 passing locally
- [x] `vendor/bin/phpunit` — full suite 27/27 passing
- [ ] CI green

## Out of scope

This is one of several gaps surfaced in the PR #10 retrospective. The rest (admin-side Block Editor data localization shape, classic editor metabox path, REST PATCH coverage, multi-taxonomy interaction) are deliberately deferred — they earn their own PRs when a regression motivates them, per the discipline established by #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/1fixdotio/categories-metabox-enhanced/pull/11" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
