### PR TITLE
Add classic editor metabox e2e coverage

### DIFF
--- a/tests/e2e/classic-editor.spec.ts
+++ b/tests/e2e/classic-editor.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect, wpCli } from './fixtures';
+
+const CLASSIC_TAX = 'cme_e2e_classic';
+const CLASSIC_CPT = 'cme_e2e_classic_post';
+const CLASSIC_OPTION = 'category-metabox-enhanced_cme_e2e_classic';
+
+const RADIO_FS_ON = {
+	type: 'radio',
+	context: 'side',
+	priority: 'default',
+	metabox_title: 'E2E Classic Tax',
+	indented: 1,
+	allow_new_terms: 1,
+	force_selection: 1,
+};
+
+function setOption(overrides: Partial<typeof RADIO_FS_ON>): void {
+	wpCli([
+		'option',
+		'update',
+		CLASSIC_OPTION,
+		JSON.stringify({ ...RADIO_FS_ON, ...overrides }),
+		'--format=json',
+	]);
+}
+
+function resetOption(): void {
+	wpCli(['option', 'update', CLASSIC_OPTION, JSON.stringify(RADIO_FS_ON), '--format=json']);
+}
+
+async function gotoNewClassicPost(page) {
+	await page.goto(`/wp-admin/post-new.php?post_type=${CLASSIC_CPT}`);
+	// Classic editor renders synchronously — no welcome guide / iframe to wait on.
+	await expect(page.locator('#post')).toBeVisible({ timeout: 10_000 });
+}
+
+/**
+ * Selectors below come straight from Taxonomy_Single_Term's render output:
+ *   <ul id="<slug>checklist">                       — radio container
+ *   <select id="<slug>checklist">                   — select container
+ *   #taxonomy-<slug>-clear                          — hidden value="0" radio (FS off only)
+ *   #<slug>_input_element                           — postbox wrapper (the meta box ID)
+ * Encoding them here keeps the asserts readable even when the metabox slug changes.
+ */
+const RADIO_LIST = `ul#${CLASSIC_TAX}checklist`;
+const SELECT_BOX = `select#${CLASSIC_TAX}checklist`;
+const CLEAR_STUB = `#taxonomy-${CLASSIC_TAX}-clear`;
+const METABOX_BOX = `#${CLASSIC_TAX}_input_element`;
+
+test.describe('Classic editor metabox — Taxonomy_Single_Term render', () => {
+	test.afterEach(() => {
+		resetOption();
+	});
+
+	test('radio mode + FS on → renders radios for every term, clear stub absent', async ({ page }) => {
+		await gotoNewClassicPost(page);
+
+		await expect(page.locator(METABOX_BOX)).toBeVisible();
+
+		const list = page.locator(RADIO_LIST);
+		await expect(list).toBeVisible();
+		await expect(list.locator('input[type="radio"]')).toHaveCount(2);
+		await expect(list.locator('label').filter({ hasText: 'Foo' })).toBeVisible();
+		await expect(list.locator('label').filter({ hasText: 'Bar' })).toBeVisible();
+
+		// FS on suppresses the value="0" stub used by Clear; the absence is
+		// what makes "force a selection" actually load-bearing for users
+		// who interact via the classic UI rather than REST.
+		await expect(page.locator(CLEAR_STUB)).toHaveCount(0);
+	});
+
+	test('radio mode + FS off → clear stub is rendered (hidden li, value="0" input)', async ({ page }) => {
+		setOption({ force_selection: 0 });
+
+		await gotoNewClassicPost(page);
+
+		const stub = page.locator(CLEAR_STUB);
+		await expect(stub).toHaveCount(1);
+		await expect(stub).toHaveAttribute('value', '0');
+	});
+
+	test('select mode + FS on → "None" option absent', async ({ page }) => {
+		setOption({ type: 'select' });
+
+		await gotoNewClassicPost(page);
+
+		const select = page.locator(SELECT_BOX);
+		await expect(select).toBeVisible();
+		// Term options exist for Foo + Bar; the value="0" placeholder must
+		// not, otherwise FS-on is silently bypassable in select mode.
+		await expect(select.locator('option[value="0"]')).toHaveCount(0);
+		await expect(select.locator('option', { hasText: 'Foo' })).toHaveCount(1);
+		await expect(select.locator('option', { hasText: 'Bar' })).toHaveCount(1);
+	});
+
+	test('select mode + FS off → "None" option rendered', async ({ page }) => {
+		setOption({ type: 'select', force_selection: 0 });
+
+		await gotoNewClassicPost(page);
+
+		const select = page.locator(SELECT_BOX);
+		await expect(select).toBeVisible();
+		await expect(select.locator('option[value="0"]')).toHaveCount(1);
+	});
+});
+
+test.describe('Classic editor metabox — save round-trip', () => {
+	test.afterEach(() => {
+		resetOption();
+	});
+
+	test('selecting a radio term + Publish → reloads with that term checked', async ({ page }) => {
+		await gotoNewClassicPost(page);
+
+		await page.locator('#title').fill('Classic save round-trip');
+
+		const list = page.locator(RADIO_LIST);
+		await list.locator('label').filter({ hasText: 'Foo' }).click();
+
+		// Publish lands at /wp-admin/post.php?post=<id>&action=edit&message=6.
+		// Wait for the redirect before inspecting the persisted state.
+		await Promise.all([
+			page.waitForURL(/post\.php\?post=\d+&action=edit/),
+			page.locator('#publish').click(),
+		]);
+
+		const url = new URL(page.url());
+		const postId = Number(url.searchParams.get('post'));
+		expect(postId).toBeGreaterThan(0);
+
+		try {
+			const checked = page.locator(`${RADIO_LIST} input[type="radio"]:checked`);
+			await expect(checked).toHaveCount(1);
+			// Walker emits value="<term_id>"; resolve that back to the slug so
+			// the assertion is term-id-independent.
+			const termId = await checked.getAttribute('value');
+			const slug = wpCli(['term', 'get', CLASSIC_TAX, termId!, '--field=slug']).trim();
+			expect(slug).toBe('foo');
+		} finally {
+			wpCli(['post', 'delete', String(postId), '--force']);
+		}
+	});
+});

--- a/tests/e2e/mu-plugins/cme-e2e-helper.php
+++ b/tests/e2e/mu-plugins/cme-e2e-helper.php
@@ -23,6 +23,8 @@ defined( 'ABSPATH' ) || exit;
 
 const CME_E2E_TAX            = 'cme_e2e';
 const CME_E2E_TAX_NO_DEFAULT = 'cme_e2e_no_default';
+const CME_E2E_TAX_CLASSIC    = 'cme_e2e_classic';
+const CME_E2E_CPT_CLASSIC    = 'cme_e2e_classic_post';
 
 add_action( 'init', static function () {
 	register_taxonomy(
@@ -54,7 +56,37 @@ add_action( 'init', static function () {
 		)
 	);
 
-	if ( ! get_option( 'cme_e2e_seeded' ) ) {
+	// Classic-editor surface: a CPT without REST support so WordPress falls
+	// back to the legacy post editor, paired with a non-REST hierarchical
+	// taxonomy. Lets the Playwright suite assert against the actual
+	// Taxonomy_Single_Term metabox DOM the plugin still ships for sites
+	// that haven't moved to Block Editor yet.
+	register_post_type(
+		CME_E2E_CPT_CLASSIC,
+		array(
+			'label'        => 'E2E Classic',
+			'public'       => true,
+			'show_ui'      => true,
+			'show_in_menu' => true,
+			'show_in_rest' => false,
+			'supports'     => array( 'title', 'editor' ),
+		)
+	);
+
+	register_taxonomy(
+		CME_E2E_TAX_CLASSIC,
+		array( CME_E2E_CPT_CLASSIC ),
+		array(
+			'label'        => 'E2E Classic Tax',
+			'hierarchical' => true,
+			'show_ui'      => true,
+			'show_in_rest' => false,
+		)
+	);
+
+	// Bumped to '2' when the classic-editor CPT/tax + Foo/Bar terms were
+	// added; re-seeds existing dev envs that still hold the v1 baseline.
+	if ( '2' !== get_option( 'cme_e2e_seeded' ) ) {
 		update_option( 'category-metabox-enhanced_' . CME_E2E_TAX, array(
 			'type'            => 'radio',
 			'context'         => 'side',
@@ -75,7 +107,17 @@ add_action( 'init', static function () {
 			'force_selection' => 1,
 		) );
 
-		update_option( 'cme_e2e_seeded', '1' );
+		update_option( 'category-metabox-enhanced_' . CME_E2E_TAX_CLASSIC, array(
+			'type'            => 'radio',
+			'context'         => 'side',
+			'priority'        => 'default',
+			'metabox_title'   => 'E2E Classic Tax',
+			'indented'        => 1,
+			'allow_new_terms' => 1,
+			'force_selection' => 1,
+		) );
+
+		update_option( 'cme_e2e_seeded', '2' );
 	}
 
 	// Idempotent term seeding — safe to run on every init since each branch
@@ -85,6 +127,8 @@ add_action( 'init', static function () {
 		array( 'tax' => CME_E2E_TAX,            'name' => 'Reviews', 'slug' => 'reviews' ),
 		array( 'tax' => CME_E2E_TAX_NO_DEFAULT, 'name' => 'Alpha',   'slug' => 'alpha' ),
 		array( 'tax' => CME_E2E_TAX_NO_DEFAULT, 'name' => 'Beta',    'slug' => 'beta' ),
+		array( 'tax' => CME_E2E_TAX_CLASSIC,    'name' => 'Foo',     'slug' => 'foo' ),
+		array( 'tax' => CME_E2E_TAX_CLASSIC,    'name' => 'Bar',     'slug' => 'bar' ),
 	) as $term ) {
 		if ( ! get_term_by( 'slug', $term['slug'], $term['tax'] ) ) {
 			wp_insert_term( $term['name'], $term['tax'], array( 'slug' => $term['slug'] ) );


### PR DESCRIPTION
## Summary
- Closes the biggest remaining e2e blind spot. The Block Editor sidebar replacement (PR #10) and REST regressions (PR #12) are covered, but the plugin's original use case — `Taxonomy_Single_Term` in the legacy post editor — had no Playwright assertions. Sites still on classic editor were one walker/render regression away from a silent UI break.
- Adds an isolated e2e fixture pair via the test mu-plugin:
  - `cme_e2e_classic_post` CPT, registered without REST so WP falls back to classic editor.
  - `cme_e2e_classic` taxonomy, hierarchical, non-REST, seeded with `Foo`/`Bar`.
  - Default plugin option for the tax is radio + FS on; specs flip via `wp option update`.
- Five new specs in `tests/e2e/classic-editor.spec.ts`:
  - Radio + FS on → terms render as radios, clear stub (`value="0"`) absent.
  - Radio + FS off → clear stub is rendered (negative control).
  - Select + FS on → `<option value="0">None</option>` absent.
  - Select + FS off → `None` option present.
  - Save round-trip → click radio, Publish, redirect to edit screen, the chosen term is still checked.
- Bumped the e2e helper's seed sentinel to `'2'` so existing dev envs re-seed the new option. CI is always fresh, so this is a no-op there; locally it just runs once on next start.

## Test plan
- [x] `npx playwright test tests/e2e/classic-editor.spec.ts` — 6 passed (setup + 5 new specs)
- [x] `npx playwright test` — 16 passed (full suite, no regressions)
- [ ] CI: Playwright job green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/1fixdotio/categories-metabox-enhanced/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
