### PR TITLE
Add e2e coverage for Quick Edit single-term enforcement

### DIFF
--- a/tests/e2e/quick-edit.spec.ts
+++ b/tests/e2e/quick-edit.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, wpCli } from './fixtures';
+import { test, expect, wpCli, gotoAdmin } from './fixtures';
 
 const TAX = 'cme_e2e_no_default';
 const REST_BASE = 'cme_e2e_no_default_terms';
@@ -38,7 +38,7 @@ test.describe('Quick Edit — single-term enforcement', () => {
 		const postId = (await created.json()).id as number;
 		createdPostIds.push(postId);
 
-		await page.goto('/wp-admin/edit.php');
+		await gotoAdmin(page, '/wp-admin/edit.php');
 
 		// Open the Quick Edit form on the row whose title matches our seed.
 		// Filtering by row first avoids accidentally hitting another post's

--- a/tests/e2e/quick-edit.spec.ts
+++ b/tests/e2e/quick-edit.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect, wpCli } from './fixtures';
+
+const TAX = 'cme_e2e_no_default';
+const REST_BASE = 'cme_e2e_no_default_terms';
+
+async function termIdBySlug(api, slug: string): Promise<number> {
+	const response = await api.get(`/wp-json/wp/v2/${REST_BASE}?slug=${slug}`);
+	expect(response.ok()).toBeTruthy();
+	const body = await response.json();
+	expect(body.length).toBe(1);
+	return body[0].id as number;
+}
+
+/**
+ * Quick Edit posts a checkbox-form to admin-ajax.php?action=inline-save —
+ * a code path our existing REST + wp-cli specs don't exercise. The user
+ * can tick multiple boxes (the standard WP UI doesn't enforce single
+ * selection at the DOM level), and the only thing keeping the
+ * single-term invariant intact is our `set_object_terms` action.
+ *
+ * Regression scenario this protects against: a refactor that gates
+ * enforcement on a request-source check (e.g., `is_rest_request()`)
+ * would silently let inline-save submissions persist multi-term state.
+ */
+test.describe('Quick Edit — single-term enforcement', () => {
+	test('checking a second term in the inline form → only last-in-form term survives', async ({ page, api, createdPostIds }) => {
+		const alphaId = await termIdBySlug(api, 'alpha');
+		const betaId = await termIdBySlug(api, 'beta');
+
+		// Seed via REST so the post starts with exactly [Alpha] on the
+		// no_default tax. Posting cme_e2e terms is unnecessary — that tax has
+		// default_term=General, which WP core auto-applies on create.
+		const titleStamp = `Quick Edit ${Date.now()}`;
+		const created = await api.post('/wp-json/wp/v2/posts', {
+			data: { title: titleStamp, status: 'publish', cme_e2e_no_default_terms: [ alphaId ] },
+		});
+		expect(created.ok()).toBeTruthy();
+		const postId = (await created.json()).id as number;
+		createdPostIds.push(postId);
+
+		await page.goto('/wp-admin/edit.php');
+
+		// Open the Quick Edit form on the row whose title matches our seed.
+		// Filtering by row first avoids accidentally hitting another post's
+		// inline button if the edit list contains older e2e fixtures.
+		const row = page.locator(`tr#post-${postId}`);
+		await expect(row).toBeVisible();
+		// WP positions .row-actions off-screen until the row receives focus
+		// or hover, so a direct click on the Quick Edit button times out
+		// "element is outside of the viewport". Hover reveals it first.
+		await row.hover();
+		await row.locator('button.editinline').click();
+
+		const editForm = page.locator(`tr#edit-${postId}`);
+		await expect(editForm).toBeVisible();
+
+		// Pre-condition: Alpha already checked (REST seed). Beta unchecked.
+		const alphaBox = editForm.locator(`input[name="tax_input[${TAX}][]"][value="${alphaId}"]`);
+		const betaBox = editForm.locator(`input[name="tax_input[${TAX}][]"][value="${betaId}"]`);
+		await expect(alphaBox).toBeChecked();
+		await expect(betaBox).not.toBeChecked();
+
+		// Tick Beta, leaving Alpha checked, so the form submits both.
+		await betaBox.check();
+
+		// Save round-trip waits on the inline-save AJAX response so the next
+		// REST read observes the post-action state, not the pre-action one.
+		await Promise.all([
+			page.waitForResponse((r) => r.url().includes('admin-ajax.php') && r.request().method() === 'POST'),
+			editForm.locator('button.save').click(),
+		]);
+		await expect(editForm).toBeHidden({ timeout: 10_000 });
+
+		// Single-term enforcement: of_cme_enforce_single_term picks the LAST
+		// id in the committed array, which mirrors form submission order
+		// (alpha < beta alphabetically in the checklist), so beta survives.
+		const response = await api.get(`/wp-json/wp/v2/posts/${postId}?context=edit`);
+		expect(response.ok()).toBeTruthy();
+		const body = await response.json();
+		expect(body[REST_BASE]).toEqual([ betaId ]);
+	});
+});


### PR DESCRIPTION
## Summary
- Quick Edit posts a checkbox-form to `admin-ajax.php?action=inline-save` — a code path none of the existing REST + wp-cli specs exercise. The inline form lets users tick multiple boxes (the standard WP UI does **not** enforce single selection at the DOM level), and the only thing keeping the single-term invariant intact when they do is our `set_object_terms` action.
- Regression scenario this protects against: a refactor that gates enforcement on a request-source check (e.g., `is_rest_request()`) would silently let inline-save submissions persist multi-term state. None of the existing specs would catch that.
- One spec in `tests/e2e/quick-edit.spec.ts`:
  - REST-seed a post with `[Alpha]` on `cme_e2e_no_default`.
  - Open Quick Edit on that row (hovering first to reveal `.row-actions`, which WP positions off-screen until hover — direct click times out otherwise).
  - Tick `Beta`, leaving `Alpha` checked, so the form submits both.
  - Wait on the inline-save AJAX response to settle, then verify via REST.
  - Assert the post resolves to exactly `[Beta]` — `of_cme_enforce_single_term` keeps the last id in the committed array, and the checklist orders alphabetically so beta lands after alpha.

## Test plan
- [x] `npx playwright test tests/e2e/quick-edit.spec.ts` — 2 passed (setup + new spec)
- [x] `npx playwright test` — 20 passed (full suite, no regressions)
- [ ] CI: Playwright job green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/1fixdotio/categories-metabox-enhanced/pull/16" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
