### PR TITLE
Retry admin goto to clear stale about:blank navigation race

### DIFF
--- a/tests/e2e/allow-new-terms.spec.ts
+++ b/tests/e2e/allow-new-terms.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, wpCli } from './fixtures';
+import { test, expect, wpCli, gotoAdmin } from './fixtures';
 
 const TAX = 'cme_e2e_no_default';
 const REST_BASE = 'cme_e2e_no_default_terms';
@@ -46,7 +46,7 @@ function deleteCreatedTerm(): void {
 }
 
 async function openPostNew(page, title: string): Promise<void> {
-	await page.goto('/wp-admin/post-new.php');
+	await gotoAdmin(page, '/wp-admin/post-new.php');
 	await page
 		.locator('.edit-post-welcome-guide button[aria-label="Close"], .editor-welcome-guide button[aria-label="Close"]')
 		.first()

--- a/tests/e2e/classic-editor.spec.ts
+++ b/tests/e2e/classic-editor.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, wpCli } from './fixtures';
+import { test, expect, wpCli, gotoAdmin } from './fixtures';
 
 const CLASSIC_TAX = 'cme_e2e_classic';
 const CLASSIC_CPT = 'cme_e2e_classic_post';
@@ -29,7 +29,7 @@ function resetOption(): void {
 }
 
 async function gotoNewClassicPost(page) {
-	await page.goto(`/wp-admin/post-new.php?post_type=${CLASSIC_CPT}`);
+	await gotoAdmin(page, `/wp-admin/post-new.php?post_type=${CLASSIC_CPT}`);
 	// Classic editor renders synchronously — no welcome guide / iframe to wait on.
 	await expect(page.locator('#post')).toBeVisible({ timeout: 10_000 });
 }

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -1,4 +1,4 @@
-import { test as base, request, type APIRequestContext } from '@playwright/test';
+import { test as base, request, type APIRequestContext, type Page } from '@playwright/test';
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
@@ -19,6 +19,26 @@ function loadCredentials(): Credentials {
  */
 export function wpCli(args: string[]): string {
 	return execFileSync('npx', ['wp-env', 'run', 'tests-cli', 'wp', ...args], { encoding: 'utf8' });
+}
+
+/**
+ * Wrap page.goto with a single retry on the Chromium-specific
+ * "Navigation ... is interrupted by another navigation to 'about:blank'"
+ * race. A stale about:blank navigation from a freshly-opened page can
+ * race the test's first goto when contexts turn over between tests; a
+ * brief wait + retry clears the stale navigation deterministically.
+ */
+export async function gotoAdmin(page: Page, url: string): Promise<void> {
+	try {
+		await page.goto(url);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		if (!message.includes('about:blank')) {
+			throw err;
+		}
+		await page.waitForTimeout(250);
+		await page.goto(url);
+	}
 }
 
 type Fixtures = {

--- a/tests/e2e/force-selection.spec.ts
+++ b/tests/e2e/force-selection.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, wpCli } from './fixtures';
+import { test, expect, wpCli, gotoAdmin } from './fixtures';
 
 const E2E_TAX = 'cme_e2e';
 const NO_DEFAULT_TAX = 'cme_e2e_no_default';
@@ -109,7 +109,7 @@ test.describe('Force selection — Settings page', () => {
 	});
 
 	test('toggling Force selection off persists across reload', async ({ page }) => {
-		await page.goto('/wp-admin/options-general.php?page=category-metabox-enhanced&tab=cme_e2e');
+		await gotoAdmin(page, '/wp-admin/options-general.php?page=category-metabox-enhanced&tab=cme_e2e');
 
 		const checkbox = page.locator('input[name="category-metabox-enhanced_cme_e2e[force_selection]"]');
 		await expect(checkbox).toBeChecked();
@@ -118,7 +118,7 @@ test.describe('Force selection — Settings page', () => {
 		await page.locator('input[type="submit"][name="submit"]').click();
 		await expect(page.locator('.notice-success, #setting-error-settings_updated')).toBeVisible({ timeout: 10_000 });
 
-		await page.goto('/wp-admin/options-general.php?page=category-metabox-enhanced&tab=cme_e2e');
+		await gotoAdmin(page, '/wp-admin/options-general.php?page=category-metabox-enhanced&tab=cme_e2e');
 		await expect(page.locator('input[name="category-metabox-enhanced_cme_e2e[force_selection]"]')).not.toBeChecked();
 	});
 });
@@ -268,7 +268,7 @@ async function termIdBySlug(api, restBase: string, slug: string): Promise<number
  * document. Sidebar panels — including ours — stay in the main DOM.
  */
 async function openPostNew(page, title: string) {
-	await page.goto('/wp-admin/post-new.php');
+	await gotoAdmin(page, '/wp-admin/post-new.php');
 
 	// Welcome guide may pop up on a fresh user; close if present, ignore if not.
 	await page


### PR DESCRIPTION
## Summary
- Address a flaky local run report:
  ```
  Error: page.goto: Navigation to "http://localhost:8889/wp-admin/post-new.php"
  is interrupted by another navigation to "about:blank"
  ```
- The pattern is a known Chromium race that fires occasionally when test contexts turn over — a stale `about:blank` navigation from a fresh page can race the test's first `goto`. Doesn't reproduce reliably (suite ran clean in 6 consecutive full-suite runs after the report), so adding a deterministic guard rather than chasing a non-deterministic root cause.
- Adds `gotoAdmin(page, url)` to `tests/e2e/fixtures.ts`: try `page.goto`, and on the specific `about:blank` interrupt error wait 250ms and retry once. Any other navigation error propagates unchanged so real failures still surface.
- Five call sites in `force-selection.spec.ts`, `allow-new-terms.spec.ts`, and `classic-editor.spec.ts` now route through the helper. PR #16 (quick-edit) uses `page.goto('/wp-admin/edit.php')` directly; rebasing it on develop after this lands will pick up the helper.

## Test plan
- [x] `npx playwright test` — 19 passed (full suite on this branch, no regressions)
- [ ] CI: Playwright + PHPUnit + Build freshness green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/1fixdotio/categories-metabox-enhanced/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
