### PR TITLE
Add WordPress Playground demo with single-term UI seed

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -13,6 +13,8 @@ Replace the checkboxes with radio buttons or a select drop-down in the built-in 
 
 == Description ==
 
+**Try it live in your browser** — [launch the WordPress Playground demo](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/1fixdotio/categories-metabox-enhanced/master/blueprint/playground.blueprint.json). Boots a WordPress instance with this plugin active, the Category taxonomy pre-configured as radio buttons, and seeded posts you can edit in the Block Editor or run through Quick Edit / Bulk Edit immediately.
+
 Thanks to [Taxonomy_Single_Term](https://github.com/WebDevStudios/Taxonomy_Single_Term), a library created by [WebDevStudios](http://webdevstudios.com/), it made my work much easier on creating this plugin.
 
 With Categories Metabox Enhanced, you can:

--- a/blueprint/README.md
+++ b/blueprint/README.md
@@ -28,12 +28,10 @@ Boot sequence when someone opens the Playground link:
 
 1. Playground boots PHP + WordPress in the browser (WASM).
 2. `installPlugin` clones the plugin source from `master` (via the `git:directory` resource) and activates it. The Block Editor sidebar bundle is read from the committed `admin/js/block-editor/build/` artifacts — no build step runs inside Playground.
-3. `writeFile` drops `mu-demo-notice.php` into `wp-content/mu-plugins/`.
-4. `writeFile` drops `seed-data.php` into `/tmp/`.
-5. `runPHP` loads WordPress and runs the seed script.
-6. The browser opens on `/wp-admin/post-new.php`; the mu-plugin notice explains where to look.
+3. `runPHP` reads the seed files out of the cloned plugin directory: it `copy()`s `mu-demo-notice.php` into `wp-content/mu-plugins/` and `require`s `seed-data.php` to set the radio option, create the categories, and insert the demo posts.
+4. The browser opens on `/wp-admin/post-new.php`; the mu-plugin notice explains where to look.
 
-Because the seed script and the mu-plugin notice are fetched from the repo's raw URLs, the Blueprint only fully reflects the live source after the seed files are pushed to `master`. The plugin itself is also fetched from `master` via `git:directory`.
+The seed files travel inside the cloned plugin source, so they always match the plugin code being installed — no separate `raw.githubusercontent.com` fetches, no chance of seed and code drifting apart between branches.
 
 ## Why `git:directory` and not a release zip
 
@@ -52,16 +50,18 @@ If a release pipeline is added later, swap the `pluginData` block to:
 
 ## Testing on a branch
 
-The Blueprint hardcodes `master` in three places:
+`pluginData.ref` is the only ref the Blueprint pins. To test changes on a branch:
 
-1. `pluginData.ref` — the git ref Playground clones the plugin from.
-2. The `raw.githubusercontent.com/.../master/blueprint/seed/mu-demo-notice.php` URL.
-3. The `raw.githubusercontent.com/.../master/blueprint/seed/seed-data.php` URL.
-
-To test changes on a branch, swap all three `master` occurrences in `playground.blueprint.json` to your branch name, push, and open:
+1. Edit `playground.blueprint.json` and change `"ref": "master"` to `"ref": "<your-branch>"`.
+2. Push the branch.
+3. Open:
 
 ```
-https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/1fixdotio/categories-metabox-enhanced/<branch>/blueprint/playground.blueprint.json
+https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/1fixdotio/categories-metabox-enhanced/<your-branch>/blueprint/playground.blueprint.json
 ```
 
-Swap them back to `master` before merging — otherwise the live demo will install whichever branch you left in there.
+Swap `ref` back to `master` before merging — otherwise the live demo will install whichever branch you left in there.
+
+## Branching model and demo availability
+
+PRs merge to `develop`; releases merge `develop` into `master`. The Blueprint manifest (`playground.blueprint.json`) and the "Try it live" link in `README.txt` both target `master`, so the public demo URL only updates when a release lands. Between merge-to-develop and the next release-to-master, the demo continues to reflect the previously released state — by design, so users always land on the version that's actually published, not in-flight work.

--- a/blueprint/README.md
+++ b/blueprint/README.md
@@ -1,0 +1,67 @@
+# Playground Demo
+
+A one-click, browser-only demo of Categories Metabox Enhanced powered by [WordPress Playground](https://wordpress.github.io/wordpress-playground/).
+
+## Try it
+
+<!-- markdownlint-disable-next-line MD034 -->
+https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/1fixdotio/categories-metabox-enhanced/master/blueprint/playground.blueprint.json
+
+Clicking the link boots WordPress in your browser with the plugin pre-installed, the `category` taxonomy pre-configured as a radio single-term UI, and a couple of seeded posts ready to play with.
+
+## What the demo shows
+
+- The **Block Editor sidebar** on `post-new.php` (the landing page) and any post-edit screen renders the Categories panel as a radio tree instead of the default checkbox tree. You can pick one — and only one.
+- The **Classic Editor metabox** (visible if you install the Classic Editor plugin) renders radio buttons in place of checkboxes.
+- **Quick Edit** and **Bulk Edit** on `edit.php` still show WordPress's default checkbox UI — the plugin doesn't override that markup — but the server-side `set_object_terms` listener coerces any multi-term commit to the last selected term, so the single-term invariant holds.
+- The **Settings page** (`Settings → Categories Metabox Enhanced`) lists every hierarchical taxonomy with its own configuration block. Switch Category between `radio`, `select`, and `checkbox` to see each variant.
+
+## Files
+
+- `playground.blueprint.json` — the Blueprint; the Playground URL above fetches this.
+- `seed/seed-data.php` — runs inside Playground's PHP. Sets the radio option, creates four extra categories, and inserts two seed posts.
+- `seed/mu-demo-notice.php` — mu-plugin that prints a context-aware admin notice on post-edit, posts-list, and the settings page. Loaded only inside the demo.
+
+## How it works
+
+Boot sequence when someone opens the Playground link:
+
+1. Playground boots PHP + WordPress in the browser (WASM).
+2. `installPlugin` clones the plugin source from `master` (via the `git:directory` resource) and activates it. The Block Editor sidebar bundle is read from the committed `admin/js/block-editor/build/` artifacts — no build step runs inside Playground.
+3. `writeFile` drops `mu-demo-notice.php` into `wp-content/mu-plugins/`.
+4. `writeFile` drops `seed-data.php` into `/tmp/`.
+5. `runPHP` loads WordPress and runs the seed script.
+6. The browser opens on `/wp-admin/post-new.php`; the mu-plugin notice explains where to look.
+
+Because the seed script and the mu-plugin notice are fetched from the repo's raw URLs, the Blueprint only fully reflects the live source after the seed files are pushed to `master`. The plugin itself is also fetched from `master` via `git:directory`.
+
+## Why `git:directory` and not a release zip
+
+The MSE sibling plugin (which this scaffolding is patterned after) installs from a pinned GitHub release zip built by `10up/action-wordpress-plugin-deploy`. CME doesn't ship that workflow yet, and the wordpress.org listing is pinned at 0.7.1 — missing every 0.8/0.9 feature (Block Editor sidebar panel, force_selection, server-side enforcement). Installing from `git:directory` against `master` is the only way the demo reflects what the readme actually describes.
+
+If a release pipeline is added later, swap the `pluginData` block to:
+
+```json
+"pluginData": {
+  "resource": "url",
+  "url": "https://github.com/1fixdotio/categories-metabox-enhanced/releases/download/<TAG>/categories-metabox-enhanced.zip"
+},
+```
+
+…and the demo gains version-pinning. Until then, every push to `master` updates the demo.
+
+## Testing on a branch
+
+The Blueprint hardcodes `master` in three places:
+
+1. `pluginData.ref` — the git ref Playground clones the plugin from.
+2. The `raw.githubusercontent.com/.../master/blueprint/seed/mu-demo-notice.php` URL.
+3. The `raw.githubusercontent.com/.../master/blueprint/seed/seed-data.php` URL.
+
+To test changes on a branch, swap all three `master` occurrences in `playground.blueprint.json` to your branch name, push, and open:
+
+```
+https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/1fixdotio/categories-metabox-enhanced/<branch>/blueprint/playground.blueprint.json
+```
+
+Swap them back to `master` before merging — otherwise the live demo will install whichever branch you left in there.

--- a/blueprint/README.md
+++ b/blueprint/README.md
@@ -27,15 +27,19 @@ Clicking the link boots WordPress in your browser with the plugin pre-installed,
 Boot sequence when someone opens the Playground link:
 
 1. Playground boots PHP + WordPress in the browser (WASM).
-2. `installPlugin` clones the plugin source from `master` (via the `git:directory` resource) and activates it. The Block Editor sidebar bundle is read from the committed `admin/js/block-editor/build/` artifacts — no build step runs inside Playground.
-3. `runPHP` reads the seed files out of the cloned plugin directory: it `copy()`s `mu-demo-notice.php` into `wp-content/mu-plugins/` and `require`s `seed-data.php` to set the radio option, create the categories, and insert the demo posts.
+2. `installPlugin` downloads the plugin source from GitHub's auto-generated source-archive zip (`/archive/<branch>.zip`) and activates it. The Block Editor sidebar bundle is read from the committed `admin/js/block-editor/build/` artifacts inside the archive — no build step runs inside Playground.
+3. `runPHP` finds the installed plugin directory via `glob()` (GitHub archives extract to `categories-metabox-enhanced-<branch>/`, not the bare `categories-metabox-enhanced/` a wp.org zip would use), `copy()`s `mu-demo-notice.php` into `wp-content/mu-plugins/`, and `require`s `seed-data.php` to set the radio option, create the categories, and insert the demo posts.
 4. The browser opens on `/wp-admin/post-new.php`; the mu-plugin notice explains where to look.
 
-The seed files travel inside the cloned plugin source, so they always match the plugin code being installed — no separate `raw.githubusercontent.com` fetches, no chance of seed and code drifting apart between branches.
+The seed files travel inside the same archive zip as the plugin code, so they always match the plugin code being installed — no separate `raw.githubusercontent.com` fetches, no chance of seed and code drifting apart between branches.
 
-## Why `git:directory` and not a release zip
+## Why a source-archive zip and not a release zip or wordpress.org slug
 
-The MSE sibling plugin (which this scaffolding is patterned after) installs from a pinned GitHub release zip built by `10up/action-wordpress-plugin-deploy`. CME doesn't ship that workflow yet, and the wordpress.org listing is pinned at 0.7.1 — missing every 0.8/0.9 feature (Block Editor sidebar panel, force_selection, server-side enforcement). Installing from `git:directory` against `master` is the only way the demo reflects what the readme actually describes.
+The MSE sibling plugin (which this scaffolding is patterned after) installs from a pinned GitHub release zip built by `10up/action-wordpress-plugin-deploy`. CME doesn't ship that workflow yet, and the wordpress.org listing is pinned at 0.7.1 — missing every 0.8/0.9 feature (Block Editor sidebar panel, force_selection, server-side enforcement). The GitHub source-archive zip is the only resource that:
+
+- Reflects what the readme actually describes (current `master`, not stale `0.7.1`).
+- Requires no release pipeline or deploy workflow.
+- Is observable end-to-end (a real zip with a documented `installPlugin` path, unlike the `git:directory` resource we tried first that failed with opaque "PHP.run() failed with exit code 255" errors and no logs).
 
 If a release pipeline is added later, swap the `pluginData` block to:
 
@@ -46,13 +50,13 @@ If a release pipeline is added later, swap the `pluginData` block to:
 },
 ```
 
-…and the demo gains version-pinning. Until then, every push to `master` updates the demo.
+…and the demo gains version-pinning, plus the install directory becomes the bare `categories-metabox-enhanced/` (no `<branch>` suffix). Until then, every push to `master` updates the demo.
 
 ## Testing on a branch
 
-`pluginData.ref` is the only ref the Blueprint pins. To test changes on a branch:
+The branch name appears in the `pluginData.url` (e.g. `archive/master.zip`). To test changes on a branch:
 
-1. Edit `playground.blueprint.json` and change `"ref": "master"` to `"ref": "<your-branch>"`.
+1. Edit `playground.blueprint.json` and change the `archive/master.zip` segment of `pluginData.url` to `archive/<your-branch>.zip`.
 2. Push the branch.
 3. Open:
 
@@ -60,7 +64,7 @@ If a release pipeline is added later, swap the `pluginData` block to:
 https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/1fixdotio/categories-metabox-enhanced/<your-branch>/blueprint/playground.blueprint.json
 ```
 
-Swap `ref` back to `master` before merging — otherwise the live demo will install whichever branch you left in there.
+Revert the URL to `archive/master.zip` before merging — otherwise the live demo will install whichever branch you left in there. The `glob()` discovery in `runPHP` works regardless of which branch the archive was generated from, so no other edits are needed for branch testing.
 
 ## Branching model and demo availability
 

--- a/blueprint/playground.blueprint.json
+++ b/blueprint/playground.blueprint.json
@@ -12,7 +12,7 @@
       "step": "installPlugin",
       "pluginData": {
         "resource": "url",
-        "url": "https://github.com/1fixdotio/categories-metabox-enhanced/archive/playground-demo.zip"
+        "url": "https://github.com/1fixdotio/categories-metabox-enhanced/archive/master.zip"
       },
       "options": { "activate": true }
     },

--- a/blueprint/playground.blueprint.json
+++ b/blueprint/playground.blueprint.json
@@ -20,7 +20,7 @@
     },
     {
       "step": "runPHP",
-      "code": "<?php require_once '/wordpress/wp-load.php'; copy('/wordpress/wp-content/plugins/categories-metabox-enhanced/blueprint/seed/mu-demo-notice.php', '/wordpress/wp-content/mu-plugins/cme-demo-notice.php'); require '/wordpress/wp-content/plugins/categories-metabox-enhanced/blueprint/seed/seed-data.php';"
+      "code": "<?php require_once '/wordpress/wp-load.php'; wp_mkdir_p('/wordpress/wp-content/mu-plugins'); copy('/wordpress/wp-content/plugins/categories-metabox-enhanced/blueprint/seed/mu-demo-notice.php', '/wordpress/wp-content/mu-plugins/cme-demo-notice.php'); require '/wordpress/wp-content/plugins/categories-metabox-enhanced/blueprint/seed/seed-data.php';"
     }
   ]
 }

--- a/blueprint/playground.blueprint.json
+++ b/blueprint/playground.blueprint.json
@@ -13,7 +13,7 @@
       "pluginData": {
         "resource": "git:directory",
         "url": "https://github.com/1fixdotio/categories-metabox-enhanced.git",
-        "ref": "master",
+        "ref": "playground-demo",
         "path": "."
       },
       "options": { "activate": true }

--- a/blueprint/playground.blueprint.json
+++ b/blueprint/playground.blueprint.json
@@ -19,24 +19,8 @@
       "options": { "activate": true }
     },
     {
-      "step": "writeFile",
-      "path": "/wordpress/wp-content/mu-plugins/cme-demo-notice.php",
-      "data": {
-        "resource": "url",
-        "url": "https://raw.githubusercontent.com/1fixdotio/categories-metabox-enhanced/master/blueprint/seed/mu-demo-notice.php"
-      }
-    },
-    {
-      "step": "writeFile",
-      "path": "/tmp/cme-seed.php",
-      "data": {
-        "resource": "url",
-        "url": "https://raw.githubusercontent.com/1fixdotio/categories-metabox-enhanced/master/blueprint/seed/seed-data.php"
-      }
-    },
-    {
       "step": "runPHP",
-      "code": "<?php require_once '/wordpress/wp-load.php'; require '/tmp/cme-seed.php';"
+      "code": "<?php require_once '/wordpress/wp-load.php'; copy('/wordpress/wp-content/plugins/categories-metabox-enhanced/blueprint/seed/mu-demo-notice.php', '/wordpress/wp-content/mu-plugins/cme-demo-notice.php'); require '/wordpress/wp-content/plugins/categories-metabox-enhanced/blueprint/seed/seed-data.php';"
     }
   ]
 }

--- a/blueprint/playground.blueprint.json
+++ b/blueprint/playground.blueprint.json
@@ -11,16 +11,14 @@
     {
       "step": "installPlugin",
       "pluginData": {
-        "resource": "git:directory",
-        "url": "https://github.com/1fixdotio/categories-metabox-enhanced.git",
-        "ref": "playground-demo",
-        "path": "."
+        "resource": "url",
+        "url": "https://github.com/1fixdotio/categories-metabox-enhanced/archive/playground-demo.zip"
       },
       "options": { "activate": true }
     },
     {
       "step": "runPHP",
-      "code": "<?php require_once '/wordpress/wp-load.php'; wp_mkdir_p('/wordpress/wp-content/mu-plugins'); copy('/wordpress/wp-content/plugins/categories-metabox-enhanced/blueprint/seed/mu-demo-notice.php', '/wordpress/wp-content/mu-plugins/cme-demo-notice.php'); require '/wordpress/wp-content/plugins/categories-metabox-enhanced/blueprint/seed/seed-data.php';"
+      "code": "<?php require_once '/wordpress/wp-load.php'; $matches = glob('/wordpress/wp-content/plugins/categories-metabox-enhanced*', GLOB_ONLYDIR); $plugin_dir = $matches ? $matches[0] : ''; if ($plugin_dir && file_exists($plugin_dir . '/blueprint/seed/seed-data.php')) { wp_mkdir_p('/wordpress/wp-content/mu-plugins'); copy($plugin_dir . '/blueprint/seed/mu-demo-notice.php', '/wordpress/wp-content/mu-plugins/cme-demo-notice.php'); require $plugin_dir . '/blueprint/seed/seed-data.php'; } else { error_log('CME demo seed: plugin directory not found, skipping seed'); }"
     }
   ]
 }

--- a/blueprint/playground.blueprint.json
+++ b/blueprint/playground.blueprint.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+  "meta": {
+    "title": "Categories Metabox Enhanced — Single-term UI Demo",
+    "author": "1fixdotio",
+    "description": "Pre-configured WordPress with the Categories metabox switched to radio buttons. Open the seeded post or create a new one to see the single-term UI in both the Block Editor sidebar and Classic Editor metabox."
+  },
+  "login": true,
+  "landingPage": "/wp-admin/post-new.php",
+  "steps": [
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "git:directory",
+        "url": "https://github.com/1fixdotio/categories-metabox-enhanced.git",
+        "ref": "master",
+        "path": "."
+      },
+      "options": { "activate": true }
+    },
+    {
+      "step": "writeFile",
+      "path": "/wordpress/wp-content/mu-plugins/cme-demo-notice.php",
+      "data": {
+        "resource": "url",
+        "url": "https://raw.githubusercontent.com/1fixdotio/categories-metabox-enhanced/master/blueprint/seed/mu-demo-notice.php"
+      }
+    },
+    {
+      "step": "writeFile",
+      "path": "/tmp/cme-seed.php",
+      "data": {
+        "resource": "url",
+        "url": "https://raw.githubusercontent.com/1fixdotio/categories-metabox-enhanced/master/blueprint/seed/seed-data.php"
+      }
+    },
+    {
+      "step": "runPHP",
+      "code": "<?php require_once '/wordpress/wp-load.php'; require '/tmp/cme-seed.php';"
+    }
+  ]
+}

--- a/blueprint/seed/mu-demo-notice.php
+++ b/blueprint/seed/mu-demo-notice.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Plugin Name: Categories Metabox Enhanced — Playground Demo Notice
+ * Description: Adds an admin notice on post-edit and posts-list screens explaining the Playground demo. Loaded only inside the Playground demo environment.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_action( 'admin_notices', function () {
+	$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+	if ( ! $screen ) {
+		return;
+	}
+
+	$relevant = in_array( $screen->id, array( 'post', 'edit-post', 'settings_page_category-metabox-enhanced' ), true );
+	if ( ! $relevant ) {
+		return;
+	}
+
+	$settings_url = admin_url( 'options-general.php?page=category-metabox-enhanced' );
+	$list_url     = admin_url( 'edit.php' );
+	?>
+	<div class="notice notice-info is-dismissible" style="border-left-color:#2271b1;">
+		<h2 style="margin:0.5em 0 0.25em;">Categories Metabox Enhanced — try it out</h2>
+		<?php if ( 'post' === $screen->id ) : ?>
+			<p style="margin:0.25em 0;">
+				The Category taxonomy is configured as <strong>radio buttons</strong>.
+				In the Block Editor sidebar, expand the <strong>Categories</strong> panel on the right to see the radio tree.
+				Pick one — you can't pick two.
+			</p>
+			<p style="margin:0.25em 0;">
+				<a href="<?php echo esc_url( $settings_url ); ?>">Switch the option type</a>
+				to <code>select</code> for the drop-down variant, or to <code>checkbox</code> to disable the plugin's UI.
+			</p>
+		<?php elseif ( 'edit-post' === $screen->id ) : ?>
+			<p style="margin:0.25em 0;">
+				Hover any row to reveal <strong>Quick Edit</strong>, then tick a second category and save —
+				the plugin's server-side enforcement coerces the post back to a single term.
+				Same applies to <strong>Bulk Edit</strong>: select two posts, tick a category in the bulk form, and only that term survives on each.
+			</p>
+			<p style="margin:0.25em 0;">
+				<a href="<?php echo esc_url( $settings_url ); ?>">Plugin settings</a>
+				let you change the option type and toggle <em>Force selection</em>, which substitutes a default term server-side when the form submits empty.
+			</p>
+		<?php else : ?>
+			<p style="margin:0.25em 0;">
+				This is the plugin's settings page. Each hierarchical taxonomy can be configured independently.
+				Try switching <strong>Category</strong> between <code>radio</code>, <code>select</code>, and <code>checkbox</code>,
+				then <a href="<?php echo esc_url( $list_url ); ?>">go back to Posts</a> to see the change.
+			</p>
+		<?php endif; ?>
+	</div>
+	<?php
+} );

--- a/blueprint/seed/seed-data.php
+++ b/blueprint/seed/seed-data.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Seed script for the Playground demo.
+ *
+ * Configures the Category taxonomy to use the radio single-term UI, creates
+ * a handful of categories so the radio panel has options, and seeds a couple
+ * of posts so the edit list and Quick Edit / Bulk Edit flows are immediately
+ * usable.
+ *
+ * Run from the Blueprint's runPHP step after wp-load.php is loaded.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	require_once '/wordpress/wp-load.php';
+}
+
+// Idempotency guard: Playground may persist state (OPFS) and re-run the
+// Blueprint, in which case we don't want duplicate categories or posts.
+if ( get_option( 'cme_demo_seeded' ) ) {
+	return;
+}
+
+// 1. Switch the built-in Category taxonomy to the radio single-term UI.
+//    The plugin's Settings page writes this same option key. Pre-seeding
+//    it means the demo lands on the radio UI on first load instead of the
+//    default checkbox UI.
+update_option(
+	'category-metabox-enhanced_category',
+	array(
+		'type'            => 'radio',
+		'context'         => 'side',
+		'priority'        => 'default',
+		'metabox_title'   => '',
+		'indented'        => 1,
+		'allow_new_terms' => 1,
+		'force_selection' => 1,
+	)
+);
+
+// 2. Seed categories. WordPress already creates "Uncategorized" on install;
+//    we add four more so the radio list has something to demonstrate.
+$category_slugs = array(
+	'tutorials' => 'Tutorials',
+	'news'      => 'News',
+	'reviews'   => 'Reviews',
+	'opinion'   => 'Opinion',
+);
+
+$category_ids = array();
+
+foreach ( $category_slugs as $slug => $name ) {
+	$existing = get_term_by( 'slug', $slug, 'category' );
+	if ( $existing instanceof WP_Term ) {
+		$category_ids[ $slug ] = (int) $existing->term_id;
+		continue;
+	}
+
+	$result = wp_insert_term( $name, 'category', array( 'slug' => $slug ) );
+	if ( ! is_wp_error( $result ) ) {
+		$category_ids[ $slug ] = (int) $result['term_id'];
+	}
+}
+
+// 3. Seed a couple of posts assigned to different categories. Two posts is
+//    enough for the user to see the metabox UI on edit, and for Bulk Edit
+//    to have multiple rows to act on.
+$posts = array(
+	array(
+		'title'    => 'Welcome to the Categories Metabox Enhanced demo',
+		'content'  => "This post is here so you have something to open in the editor.\n\nOpen this post in the Block Editor and look at the right sidebar — the Categories panel renders as a radio tree. Try the same in the Classic Editor (you can switch via the Classic Editor plugin) and you'll see radio buttons instead of checkboxes.\n\nQuick Edit and Bulk Edit on the posts list still render WordPress's default checkbox UI, but server-side enforcement coerces multi-term submissions to a single term — try ticking two boxes in Quick Edit and saving.",
+		'category' => 'tutorials',
+	),
+	array(
+		'title'    => 'Second post — try Quick Edit on this one',
+		'content'  => "Hover over a row on Posts → All Posts to reveal Quick Edit. Tick a second category and save — you'll only see one survive.",
+		'category' => 'news',
+	),
+);
+
+foreach ( $posts as $item ) {
+	$category_id = isset( $category_ids[ $item['category'] ] ) ? $category_ids[ $item['category'] ] : 0;
+
+	$post_id = wp_insert_post(
+		array(
+			'post_title'    => $item['title'],
+			'post_content'  => $item['content'],
+			'post_status'   => 'publish',
+			'post_type'     => 'post',
+			'post_category' => $category_id ? array( $category_id ) : array(),
+		)
+	);
+
+	if ( is_wp_error( $post_id ) || ! $post_id ) {
+		error_log( 'CME demo seed: wp_insert_post failed for ' . $item['title'] );
+	}
+}
+
+update_option( 'cme_demo_seeded', 1 );
+
+error_log( 'CME demo seed: completed' );


### PR DESCRIPTION
## Summary

- Mirrors the blueprint scaffolding from the sibling `media-search-enhanced` plugin so users can launch a one-click browser demo from the readme — no local WordPress install needed.
- The Blueprint installs the plugin from this repo's `master` via `git:directory` (committed `admin/js/block-editor/build/` artifacts mean Playground doesn't need to run a JS build), drops a context-aware mu-plugin notice, and runs a seed script that switches the Category taxonomy to the radio single-term UI, creates four extra categories, and inserts two demo posts.
- Surfaces a "Try it live in your browser" link in `README.txt`'s Description so .org visitors discover the demo without digging into the repo.

## Resource choice — why `git:directory` instead of a release zip

MSE pins to a release zip built by `10up/action-wordpress-plugin-deploy`. CME can't use that pattern yet:

- The wordpress.org listing is pinned at **0.7.1**, missing every 0.8/0.9 feature (Block Editor sidebar panel, force_selection, server-side enforcement). `wordpress.org/plugins` would install a misleading demo.
- No GitHub release / deploy workflow exists yet.

`git:directory` against `master` is the only resource that reflects what the readme actually describes. Trade-off: every push to `master` updates the live demo. `blueprint/README.md` documents the swap-to-release-zip path for when a deploy pipeline lands.

## Files added

- `blueprint/playground.blueprint.json` — Blueprint manifest. `installPlugin` → `writeFile` × 2 → `runPHP`. Lands on `/wp-admin/post-new.php`.
- `blueprint/seed/seed-data.php` — sets `category-metabox-enhanced_category` to `type=radio` + `force_selection=1`, creates Tutorials/News/Reviews/Opinion, inserts two demo posts. Idempotent via the `cme_demo_seeded` option (Playground OPFS persistence won't duplicate seeds on re-runs).
- `blueprint/seed/mu-demo-notice.php` — `admin_notices` mu-plugin with separate copy for post-edit, posts-list, and the settings page.
- `blueprint/README.md` — explains the demo, file roles, boot sequence, branch-testing workflow, and the release-zip migration path.

## Important caveat

The Blueprint hardcodes `master` in three places: the `pluginData.ref` and the two `raw.githubusercontent.com/.../master/...` seed URLs. The "Try it live" link in `README.txt` also points at `master`. **The demo URL won't actually work until this PR lands on `master`** — until then, branch-test by swapping the three `master` references in `playground.blueprint.json` to `playground-demo`, pushing, and opening:

```
https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/1fixdotio/categories-metabox-enhanced/playground-demo/blueprint/playground.blueprint.json
```

Swap them back before merge.

## Test plan

- [ ] Clone the demo from a `master`-targeted Blueprint URL after merge and confirm the radio Categories panel appears in the Block Editor sidebar on the landing page.
- [ ] Confirm the seeded posts on `/wp-admin/edit.php` exist (Welcome post → Tutorials, "try Quick Edit" post → News).
- [ ] Open Quick Edit on a seeded row, tick a second category, save, and verify only the last selection persists.
- [ ] Bulk-select both posts, tick a category in the bulk form, save, and verify each post ends up at the bulk-form term.
- [ ] Switch the option type to `select` on the Settings page, reload a post-edit screen, and confirm the dropdown variant.
- [ ] Toggle Force selection off, save with no category checked via REST PATCH, and confirm the post stays empty (no default substitution).
- [ ] Reload the Blueprint URL a second time and confirm `cme_demo_seeded` short-circuits the seed (no duplicate categories or posts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/1fixdotio/categories-metabox-enhanced/pull/19" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
