### PR TITLE
Fix WP test-suite install for x.0 major releases

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -35,14 +35,15 @@ download() {
 	fi
 }
 
-# WordPress doesn't tag x.y.0 patches separately — they live under tags/x.y.
-# Normalize so both the explicit x.y.z branch and the `latest`-via-API branch
-# agree on the SVN path.
+# WordPress doesn't tag three-part x.y.0 patches separately — they live under
+# tags/x.y. But two-part major releases keep their zero: 7.0 is tagged tags/7.0,
+# not tags/7. Only strip the trailing .0 for x.y.0, so both the explicit x.y.z
+# branch and the `latest`-via-API branch agree on the SVN path.
 release_tag_for() {
 	local v="$1"
 	case "$v" in
-		*.0) echo "tags/${v%.0}" ;;
-		*)   echo "tags/$v" ;;
+		*.*.0) echo "tags/${v%.0}" ;;
+		*)     echo "tags/$v" ;;
 	esac
 }
 


### PR DESCRIPTION
## Summary

CI's PHPUnit job is failing at the "Install WordPress test suite" step for every branch, with:

```
svn: E170000: URL 'https://develop.svn.wordpress.org/tags/7/tests/phpunit/includes' doesn't exist
```

`release_tag_for()` in `bin/install-wp-tests.sh` strips the trailing `.0` from **any** `*.0` version. That's correct for three-part patch versions (`6.8.0` → `tags/6.8`, since WordPress doesn't tag `.0` patches separately), but wrong for two-part major releases: WordPress tags `7.0` as **`tags/7.0`**, not `tags/7`. Once `api.wordpress.org` started reporting `7.0` as "latest", the install step broke.

## Fix

Narrow the glob from `*.0` to `*.*.0`, so only three-part `x.y.0` releases lose the `.0`; two-part `x.0` majors keep it.

Verified against live `develop.svn.wordpress.org` tags:

| input | resolved tag | exists |
|-------|--------------|--------|
| `7.0`   | `tags/7.0`   | ✅ |
| `6.0`   | `tags/6.0`   | ✅ |
| `6.8`   | `tags/6.8`   | ✅ |
| `6.8.0` | `tags/6.8`   | ✅ |
| `6.8.1` | `tags/6.8.1` | ✅ |
| `6.9.4` | `tags/6.9.4` | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
