### PR TITLE
Fix wp.org deploy: exclude .git from the package

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -4,6 +4,7 @@
 # committed block-editor build/ + src/ (src kept for the human-readable-code guideline).
 
 # Dev tooling & CI
+/.git
 /.github
 /bin
 /tests


### PR DESCRIPTION
## Hotfix: exclude `.git` from the WordPress.org deploy package

The 0.9.1 deploy to wp.org [failed](https://github.com/1fixdotio/categories-metabox-enhanced/actions/runs/27686221523/job/81885469389) with:

```
svn: E195023: Changing file '.../assets/banner-772x250.png' is forbidden by the server
```

### Root cause
When `.distignore` was adapted from `media-search-enhanced`, the **`/.git`** entry was dropped. The 10up deploy action therefore copied the entire `.git/` directory into SVN `trunk/` and `tags/0.9.1/`. wp.org's pre-commit hook rejects a changeset containing a nested VCS directory; the error surfaced on the first transmitted file (`assets/banner-772x250.png`), which made it look like an assets/permissions problem.

Confirmed it's **not** an assets issue: the sibling plugin's wp.org assets carry `svn:mime-type = image/png` (set by the same action), so wp.org accepts the mime-type change the action makes. And it's **not** a commit-access issue — it reproduced after adding a committer.

The failure was **atomic**, so nothing was published — wp.org is still on 0.7.1.

### Fix
Re-add `/.git` to `.distignore` so only runtime files ship.

After merge: the `0.9.1` release/tag will be recreated on the fixed `master` commit to re-fire the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
