### PR TITLE
Fix PHP 8.2+ dynamic property deprecations (PHP 8.3 compat)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Donate link: http://1fix.io/
 Tags: category, metabox, taxonomy
 Requires at least: 5.5
 Tested up to: 7.0
-Stable tag: 0.9.1
+Stable tag: 0.9.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -66,6 +66,9 @@ Set the `default_<taxonomy>` option (e.g. the built-in "Default Post Category" u
 3. A settings page for this plugin
 
 == Changelog ==
+
+= 0.9.2 =
+* Fix PHP 8.2+ "Creation of dynamic property is deprecated" notices by declaring the previously undeclared properties on `Taxonomy_Single_Term` (`$namefield`), `Taxonomy_Single_Term_Walker` (`$hierarchical`, `$input_element`), and `Category_Metabox_Enhanced_Admin` (`$plugin_screen_hook_suffix`). No behavior change.
 
 = 0.9.1 =
 * Fix server-side single-term enforcement, which was registered against `pre_set_object_terms` — a hook that does not exist in WordPress core — and never executed in 0.9.0. The handler now hooks `set_object_terms` and re-issues `wp_set_object_terms` with a corrected list when the single-term contract is violated, so REST and programmatic callers are now actually enforced. The classic-editor metabox path was unaffected; it relies on UI-level enforcement.

--- a/admin/class-category-metabox-enhanced-admin.php
+++ b/admin/class-category-metabox-enhanced-admin.php
@@ -41,6 +41,15 @@ class Category_Metabox_Enhanced_Admin {
 	private $version;
 
 	/**
+	 * The hook suffix of the plugin's settings page.
+	 *
+	 * @since    0.4.0
+	 * @access   private
+	 * @var      string $plugin_screen_hook_suffix The settings page hook suffix.
+	 */
+	private $plugin_screen_hook_suffix;
+
+	/**
 	 * Initialize the class and set its properties.
 	 *
 	 * @since    0.1.0

--- a/categories-metabox-enhanced.php
+++ b/categories-metabox-enhanced.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Categories Metabox Enhanced
  * Plugin URI:        https://1fix.io/category-metabox-enhanced/
  * Description:       Replace the checkboxes with radio buttons or a select drop-down in the built-in Categories metabox and the Block Editor sidebar panel.
- * Version:           0.9.1
+ * Version:           0.9.2
  * Requires at least: 5.5
  * Author:            1Fix.io
  * Author URI:        https://1fix.io/

--- a/includes/class-category-metabox-enhanced.php
+++ b/includes/class-category-metabox-enhanced.php
@@ -69,7 +69,7 @@ class Category_Metabox_Enhanced {
 	public function __construct() {
 
 		$this->plugin_name = 'category-metabox-enhanced';
-		$this->version     = '0.9.1';
+		$this->version     = '0.9.2';
 
 		$this->load_dependencies();
 		$this->set_locale();

--- a/includes/taxonomy-single-term/class.taxonomy-single-term.php
+++ b/includes/taxonomy-single-term/class.taxonomy-single-term.php
@@ -127,6 +127,13 @@ class Taxonomy_Single_Term {
 	protected $default = array();
 
 	/**
+	 * The form field name attribute for the taxonomy input element
+	 * @since 0.1.0
+	 * @var string
+	 */
+	protected $namefield = '';
+
+	/**
 	 * Initiates our metabox action
 	 * @since 0.1.0
 	 * @param string $tax_slug      Taxonomy slug

--- a/includes/taxonomy-single-term/walker.taxonomy-single-term.php
+++ b/includes/taxonomy-single-term/walker.taxonomy-single-term.php
@@ -14,6 +14,20 @@ class Taxonomy_Single_Term_Walker extends Walker {
 	public $tree_type = 'category';
 	public $db_fields = array( 'parent' => 'parent', 'id' => 'term_id' ); //TODO: decouple this
 
+	/**
+	 * Whether the taxonomy is hierarchical.
+	 * @since 0.1.2
+	 * @var bool
+	 */
+	public $hierarchical;
+
+	/**
+	 * The input element to render (radio or select).
+	 * @since 0.1.2
+	 * @var string
+	 */
+	public $input_element;
+
 	public function __construct( $hierarchical, $input_element ) {
 		$this->hierarchical = $hierarchical;
 		$this->input_element = $input_element;


### PR DESCRIPTION
## Summary

Fixes #26 — PHP 8.2 deprecated *"Creation of dynamic property … is deprecated"*, which surfaces as warnings on PHP 8.2/8.3. The reporter hit two warnings (`Taxonomy_Single_Term::$namefield`, `Category_Metabox_Enhanced_Admin::$plugin_screen_hook_suffix`). A sweep of the plugin's own classes turned up **two more latent cases** the reporter's code paths simply didn't trigger, in `Taxonomy_Single_Term_Walker`.

All four previously-undeclared properties are now declared on their classes:

| Class | Property | Visibility (matches siblings) |
|---|---|---|
| `Taxonomy_Single_Term` | `$namefield` | `protected` |
| `Taxonomy_Single_Term_Walker` | `$hierarchical` | `public` |
| `Taxonomy_Single_Term_Walker` | `$input_element` | `public` |
| `Category_Metabox_Enhanced_Admin` | `$plugin_screen_hook_suffix` | `private` |

No behavior change — every property was already assigned before use; this only declares them so PHP no longer treats them as dynamic. `#[\AllowDynamicProperties]` was deliberately **not** used (it suppresses rather than fixes).

## Release

Bumps `Version` / `Stable tag` to **0.9.2** and adds a changelog entry, so the fix can actually ship to wp.org / wpackagist (the issue also noted the public listing was stale).

## Verification

On PHP 8.3.31 locally:
- `php -l` clean on all changed files.
- Reflection confirms all four properties are now declared.
- Constructing `Taxonomy_Single_Term_Walker` with deprecations promoted to errors raises **no** dynamic-property deprecation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)